### PR TITLE
Update documentation to reflect usage of new form API

### DIFF
--- a/source/available-services/index.rst
+++ b/source/available-services/index.rst
@@ -3,8 +3,8 @@ Available services and products
 
 Techniek Nederland Forms offers the following services:
 
-    1.  **FGO Plus** -- A service for accessing product information and forms related to FGO Plus.
-    2.  **FGO Plus Webservice** -- A web service that allows integration with FGO Plus forms and functionalities.
+    1.  **FGO Plus** -- A service for accessing product information and checklist forms related to FGO Plus.
+    2.  **FGO Plus Webservice** -- A web service that allows integration with FGO Plus checklist forms and functionalities.
     3.  **FormulierenApp** -- An application for accessing and utilizing forms provided by Techniek Nederland.
     4.  **Forms Webservice** -- A web service for integrating Techniek Nederland forms into external applications.
     5.  **Melding onveilige situatie** -- A service specifically designed for reporting unsafe situations.

--- a/source/forms.rst
+++ b/source/forms.rst
@@ -42,7 +42,7 @@ Form technology
 
 The Form API makes use of `Schema JSON <https://json-schema.org>`_ for
 all definitions of data and also forms. This allows for each company to transform
-the document into a format that is usable by there application.
+the document into a format that is usable by their application.
 
 When defining the components, the naming conventions as used
 by `FormIO <https://github.com/formio/formio.js/wiki/Components-JSON-Schema>`_. will be used. This means that

--- a/source/tutorials/authentication/service_invocation.rst
+++ b/source/tutorials/authentication/service_invocation.rst
@@ -48,4 +48,5 @@ Below you find an example of the HTTP call.
         }
 
 The response is outside of scope for this tutorial. Please see the other tutorials on requesting the webservices
-or take a look at the Swagger documentation of the FGO Webservice (https://api.fgoplus.nl/swagger/index.html)
+or take a look at the Swagger documentation of the FGO Webservice (https://api.fgoplus.nl/swagger/index.html). For
+the forms API, which is used to retrieve all forms other than checklists, please refer to https://formsapi.technieknederland.nl/swagger/index.html.

--- a/source/tutorials/authentication/user_authentication.rst
+++ b/source/tutorials/authentication/user_authentication.rst
@@ -88,7 +88,7 @@ based on your specific OAuth implementation and Postman version.
 
 
 
-Step 3: Authorize your application to act on the users behalf
+Step 3: Authorize your application to act on the user's behalf
 ===============================================================
 
 In the authorization step, you will authorize your application to perform actions on behalf of the user. It's

--- a/source/tutorials/fgo/index.rst
+++ b/source/tutorials/fgo/index.rst
@@ -4,7 +4,8 @@ The FGO (Fabrikaat Gebonden Onderhoud) Web Service is an application developed b
 the maintenance of installations. These tutorials provide an overview of the FGO Web Service and guides developer
 on how to perform various actions using the service. It is important to note that using the web service requires
 user authentication, which is covered in separate tutorials on :ref:`tutorials/authentication/index:authentication`.
-For a complete documentation on the API itself, please see https://api.fgoplus.nl/swagger/index.html.
+For a complete documentation on the FGO Plus API itself, please see https://api.fgoplus.nl/swagger/index.html. For the Techniek
+Nederland forms API, please see https://formsapi.technieknederland.nl/swagger/index.html.
 
 
 .. toctree::

--- a/source/tutorials/fgo/retrieving_installation_information.rst
+++ b/source/tutorials/fgo/retrieving_installation_information.rst
@@ -4,7 +4,7 @@ Retrieving Installation Information
 This guide will walk you through the process of accessing various details, including the name, serial number,
 power rating, safety instructions, and any additional remarks related to the installations and its maintenance.
 This tutorial aims to provide a comprehensive understanding of how to retrieve product information using
-the FGO webservice. It covers the following key topics:
+the FGO Plus webservice. It covers the following key topics:
 
 .. contents::
    :depth: 2
@@ -12,7 +12,7 @@ the FGO webservice. It covers the following key topics:
    :backlinks: none
 
 
-Before diving into the tutorial, ensure that you have the necessary credentials and access to the FGO webservice.
+Before diving into the tutorial, ensure that you have the necessary credentials and access to the FGO Plus webservice.
 Familiarize yourself with the authentication process, as mentioned in the
 documentation page on :ref:`tutorials/authentication/index:authentication`.
 
@@ -25,7 +25,7 @@ And last but not least: have a look at the Swagger documentation available at ht
 Querying Products
 =================
 
-The first step in retrieving product information from the FGO webservice is to search the catalog using specific
+The first step in retrieving product information from the FGO Plus webservice is to search the catalog using specific
 product names or properties (Type, Brand, model etc).
 
 
@@ -113,7 +113,7 @@ property `items` is an array of search results. We list the most relevant proper
 
 Retrieving available filters and their options
 ==============================================
-In addition to free-text searching, the FGO webservice also provides the capability to filter results based
+In addition to free-text searching, the FGO Plus webservice also provides the capability to filter results based
 on specific properties. This feature, known as faceted search, allows you to refine your search results further
 based on various criteria. Before you can filter the product search, we have to retrieve the list of
 available options.

--- a/source/tutorials/get_forms.rst
+++ b/source/tutorials/get_forms.rst
@@ -2,11 +2,12 @@ Get forms for an installation
 -------------------------------------
 
 Once you've determined the ETIM Product Class for you installation, you can query the Forms API for relevant forms.
+For the documentation on the forms API, please see https://formsapi.technieknederland.nl/swagger/index.html.
 
 Get a list of relevant forms
 ++++++++++++++++++++++++++++
 
-.. http:get:: https://api.fgoplus.nl/api/v1/Fgo/Forms/Latest
+.. http:get:: https://formsapi.technieknederland.nl/api/v1/Forms/Latest
 
    Returns a list of forms relevant for you installation
 
@@ -14,8 +15,8 @@ Get a list of relevant forms
 
    .. sourcecode:: http
 
-      GET /api/v1/Fgo/Forms/All?classCode=EC010232 HTTP/1.1
-      Host: api.fgoplus.nl
+      GET /api/v1/Forms/All?classCode=EC010232 HTTP/1.1
+      Host: formsapi.technieknederland.nl
       Accept: application/json
       Authorization: OAuth token to authenticate
 
@@ -45,7 +46,7 @@ Get a list of relevant forms
 Get the form itself
 ++++++++++++++++++++++++++++
 
-.. http:get:: https://api.fgoplus.nl/api/v1/Fgo/Form/[code]/[version]/
+.. http:get:: https://formsapi.technieknederland.nl/api/v1/Form/[code]/[version]/
 
    Returns the requested form
 
@@ -53,8 +54,8 @@ Get the form itself
 
    .. sourcecode:: http
 
-      GET /api/v1/Fgo/Forms/Form/FGO00002/2/ HTTP/1.1
-      Host: api.fgoplus.nl
+      GET /api/v1/Form/FGO00002/2/ HTTP/1.1
+      Host: formsapi.technieknederland.nl
       Accept: application/json
       Authorization: OAuth token to authenticate
 


### PR DESCRIPTION
* Make clear that fgo plus is only used for checklist forms and all other forms go via the forms API.
* Add links to forms API documentation
* Update forms API examples to use new URL
* Fix other typos found.