### PR TITLE
FGO-425: add 'known as BAG ID' after kadaster ID for clarity

### DIFF
--- a/source/architecture.rst
+++ b/source/architecture.rst
@@ -69,7 +69,7 @@ Object (Building, Gebouw, Bouwwerk, Pand, Werkadres)
 #####################################################
 Most of the times an Object will be a building, but it could also be for instance a meadow (solar panels).
 Objects in the Netherlands are registered by the Kadaster.
-Each Object (and sub-object) is documented with a unique Kadaster ID (VBO). See
+Each Object (and sub-object) is documented with a unique Kadaster ID (VBO), also known as BAG ID. See
 https://www.kadaster.nl/zakelijk/producten/adressen-en-gebouwen/bag-api-individuele-bevragingen and
 https://catalogus.kadaster.nl/bag/nl/page/Verblijfsobject.
 

--- a/source/tutorials/describe_installation.rst
+++ b/source/tutorials/describe_installation.rst
@@ -15,7 +15,7 @@ Basic model for an Installation
     .. attribute:: building_id
 
         A reference to the Object/Building in which this system is installed. It's up to you if you choose
-        to use a Kadaster ID (VBO) or something of your own. In the (near) future it might be relevant to save extra information
+        to use a Kadaster ID (VBO), also known as BAG ID, or something of your own. In the (near) future it might be relevant to save extra information
         in your database, regarding for instance the year of build for the Object in which the installation has been
         installed. For now, the building is not used for filtering yet.
 


### PR DESCRIPTION
Feedback op ticket 425 (https://trello.com/c/uixOJpG9/425-bag-id-aanpassen-naar-kadaster-id), vermelden dat Kadaster ID ook bekend is als BAG ID.